### PR TITLE
Edge - Publish API v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,9 @@ submitFirefox({
 })
 
 submitEdge({
-  clientId: "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
-  clientSecret: "abcdefg",
   productId: "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
-  accessTokenUrl: "https://login.microsoftonline.com/aaaaaaa-aaaa-bbbb-cccc-dddddddddddd/oauth2/v2.0/token",
+  clientId: "aaaaaaa-aaaa-bbbb-cccc-dddddddddddd",
+  apiKey: "abcdefg",
   zip: "dist/some-zip-v{version}.zip",
   notes: "Changes for reviewers",
   verbose: false

--- a/tokens.md
+++ b/tokens.md
@@ -44,16 +44,15 @@ Returns `Promise<true>` or throws an exception on failure.
 
 Returns `Promise<true>` or throws an exception.
 
-## Edge Add-ons API
+## Edge Add-ons API (v1.1)
 
 `submitEdge`
 
 | Argument         | Type   | How to Obtain                                                                                                                               |
-| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------| ------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `productId`      | string | Create an edge add-on and go to the dashboard: `https://partner.microsoft.com/en-us/dashboard/microsoftedge/{product-id}/package/dashboard` |
 | `clientId`       | string | https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi                                                                      |
-| `clientSecret`   | string | https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi                                                                      |
-| `accessTokenUrl` | string | https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi                                                                      |
+| `apiKey`         | string | https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi                                                                      |
 
 Returns `Promise<true>` or throws an exception.
 


### PR DESCRIPTION
Enable Edge Store publishing using the Publish API v1.1. 

More context can be seen in https://github.com/PlasmoHQ/edge-addons-api/issues/86.

🚨 https://github.com/PlasmoHQ/edge-addons-api/pull/87 needs to be updated first, then this needs to update it's dependency of it.